### PR TITLE
Fix debezium

### DIFF
--- a/week05/sem/demo2_debezium/docker-compose.yaml
+++ b/week05/sem/demo2_debezium/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
 
   # Debezium Backend
   debezium:
-    image: debezium/connect:latest
+    image: quay.io/debezium/connect:latest
     restart: always
     container_name: debezium
     hostname: debezium


### PR DESCRIPTION
Dockerhub image has been relocated to quay.io/debezium/connect⁠. Fix debezium image source